### PR TITLE
Fix MT1300 path name error

### DIFF
--- a/images.json
+++ b/images.json
@@ -95,7 +95,7 @@
 			"disabled": 0,
 			"profile": "gl-mt1300",
 			"version": "3.212",
-			"imagebuilder": "3.8/openwrt-imagebuilder-ramips-mt7621-newdriver_3.8",
+			"imagebuilder": "3.8/openwrt-imagebuilder-ramips-mt7621_3.8",
 			"packages": "$basic $storage $usb $glinet $vpn -kmod-mt76x2 -kmod-mt7603 kmod-mt7615 gl-qos-internal -gl-qos gl-base-files-mt -wpad-basic -lighttpd-mod-openssl gl-ble-ubus gl-ble_cfg_router_telink gl-ipv6 gl-tor kmod-i2c-algo-bit kmod-i2c-core kmod-i2c-gpio kmod-i2c-gpio-custom i2c-tools libiwinfo-lua minidlna wireless-tools kmod-sdhci kmod-sdhci-mt7620 kmod-nft-core kmod-nft-nat kmod-nft-offload gl-upload gl-rtty gl-sdk4-mtk-wifi gl-sdk4-mtk-apcli -i2c-tools luci luci-mod-rpc luci-base"
 		},
 		"mt300n-v2": {

--- a/images.json
+++ b/images.json
@@ -1,6 +1,6 @@
 {
 	"packages": {
-		"basic": "libustream-openssl -dnsmasq dnsmasq-full -wpad-mini iwinfo kmod-nls-cp437 kmod-nls-iso8859-1 kmod-nls-utf8 kmod-nf-nathelper kmod-nf-nathelper-extra ethtool fcgi lighttpd lighttpd-mod-access lighttpd-mod-cgi lighttpd-mod-expire lighttpd-mod-fastcgi lighttpd-mod-proxy unzip wpa-cli bridge ip-full -unbound stubby mwan3 -wpad-basic wpad-openssl -PCI_SUPPORT -luci -luci-mod-rpc ipset",
+		"basic": "libustream-openssl -dnsmasq dnsmasq-full -wpad-mini iwinfo kmod-nls-cp437 kmod-nls-iso8859-1 kmod-nls-utf8 kmod-nf-nathelper kmod-nf-nathelper-extra ethtool fcgi lighttpd lighttpd-mod-access lighttpd-mod-cgi lighttpd-mod-expire lighttpd-mod-fastcgi lighttpd-mod-proxy unzip wpa-cli bridge ip-full -unbound stubby mwan3 -wpad-basic wpad-openssl -PCI_SUPPORT luci luci-mod-rpc ipset",
 		"vpn": "openvpn-openssl wireguard gl-wg gl-wg-server gl-vpn gl-vpn-server -gl-ss -gl-ss-server",
 		"storage": "blkid kmod-fs-ext4 kmod-fs-ntfs kmod-fs-vfat kmod-fs-exfat ntfs-3g -samba36-server -minidlna",
 		"usb": "kmod-usb-storage-uas kmod-usb-storage kmod-usb-uhci kmod-usb2 kmod-usb-ohci kmod-usb-acm kmod-usb-net-huawei-cdc-ncm comgt chat comgt-directip comgt-ncm kmod-usb-serial kmod-usb-serial-cp210x kmod-usb-serial-option kmod-usb-serial-wwan kmod-usb-serial-sierrawireless kmod-rt2800-usb usb-modeswitch kmod-mppe kmod-usb-net kmod-usb-net-cdc-ether kmod-usb-net-rndis kmod-usb-net-qmi-wwan uqmi kmod-usb-net-ipheth libusbmuxd libimobiledevice usbmuxd",
@@ -16,7 +16,7 @@
 			"version": "3.211",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar gl-base-files-x1200 $basic $vpn $storage $usb $glinet gl-ui gl-tor -gl-ui-x1200 -gl-qos gl-qos-internal gl-gps gl-uart kmod-fast-classifier kmod-shortcut-fe gl-upload gl-rtty ath10k-firmware-qca9888-ct-htt -ath10k-firmware-qca9888 kmod-ath10k-ct -kmod-ath10k smstools3 ssmtp"
+			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar gl-base-files-x1200 $basic $vpn $storage $usb $glinet gl-ui gl-tor -gl-ui-x1200 -gl-qos gl-qos-internal gl-gps gl-uart kmod-fast-classifier kmod-shortcut-fe gl-upload gl-rtty ath10k-firmware-qca9888-ct-htt -ath10k-firmware-qca9888 kmod-ath10k-ct -kmod-ath10k smstools3 ssmtp -luci -luci-mod-rpc"
 		},
 		"ar150": {
 			"state": "develop",
@@ -24,7 +24,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet"
+			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet -luci -luci-mod-rpc"
 		},
 		"mifi": {
 			"state": "develop",
@@ -32,7 +32,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar $basic $vpn $storage $usb $glinet gl-rtty smstools3 ssmtp"
+			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar $basic $vpn $storage $usb $glinet gl-rtty smstools3 ssmtp -luci -luci-mod-rpc"
 		},
 		"e750": {
 			"state": "develop",
@@ -40,7 +40,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar gl-base-files-e750 $basic $vpn $storage $usb $glinet gl-e750-mcu gl-tor gl-upload gl-rtty smstools3 ssmtp luci luci-mod-rpc luci-base"
+			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar gl-base-files-e750 $basic $vpn $storage $usb $glinet gl-e750-mcu gl-tor gl-upload gl-rtty smstools3 ssmtp luci-base"
 		},
 		"ar300m16": {
 			"state": "develop",
@@ -48,7 +48,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet"
+			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet -luci -luci-mod-rpc"
 		},
 		"ar750": {
 			"state": "develop",
@@ -56,7 +56,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet"
+			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet -luci -luci-mod-rpc"
 		},
 		"x750": {
 			"state": "develop",
@@ -64,7 +64,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar gl-bletool $basic $vpn $storage $usb $glinet -gl-qos gl-qos-internal gl-rtty gl-upload smstools3 ssmtp"
+			"packages": "kmod-GobiNet kmod-GobiSerial gl-base-files-ar gl-bletool $basic $vpn $storage $usb $glinet -gl-qos gl-qos-internal gl-rtty gl-upload smstools3 ssmtp -luci -luci-mod-rpc"
 		},
 		"usb150": {
 			"state": "develop",
@@ -72,7 +72,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $glinet -mwan3 -gl-modem"
+			"packages": "gl-base-files-ar $basic $vpn $glinet -mwan3 -gl-modem -luci -luci-mod-rpc"
 		},
 		"ar300m": {
 			"state": "develop",
@@ -80,7 +80,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet ath10k-firmware-qca9887 kmod-ath10k gl-tor"
+			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet ath10k-firmware-qca9887 kmod-ath10k gl-tor -luci -luci-mod-rpc"
 		},
 		"ar750s": {
 			"state": "develop",
@@ -88,7 +88,7 @@
 			"profile": "glinet_gl-ar750s-nor-nand",
 			"version": "3.212",
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet kmod-fast-classifier kmod-shortcut-fe gl-tor gl-upload gl-rtty luci luci-mod-rpc luci-base"
+			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet kmod-fast-classifier kmod-shortcut-fe gl-tor gl-upload gl-rtty luci-base"
 		},
 		"mt1300": {
 			"state": "develop",
@@ -96,7 +96,7 @@
 			"profile": "gl-mt1300",
 			"version": "3.212",
 			"imagebuilder": "3.8/openwrt-imagebuilder-ramips-mt7621_3.8",
-			"packages": "$basic $storage $usb $glinet $vpn -kmod-mt76x2 -kmod-mt7603 kmod-mt7615 gl-qos-internal -gl-qos gl-base-files-mt -wpad-basic -lighttpd-mod-openssl gl-ble-ubus gl-ble_cfg_router_telink gl-ipv6 gl-tor kmod-i2c-algo-bit kmod-i2c-core kmod-i2c-gpio kmod-i2c-gpio-custom i2c-tools libiwinfo-lua minidlna wireless-tools kmod-sdhci kmod-sdhci-mt7620 kmod-nft-core kmod-nft-nat kmod-nft-offload gl-upload gl-rtty gl-sdk4-mtk-wifi gl-sdk4-mtk-apcli -i2c-tools luci luci-mod-rpc luci-base"
+			"packages": "$basic $storage $usb $glinet $vpn -kmod-mt76x2 -kmod-mt7603 kmod-mt7615 gl-qos-internal -gl-qos gl-base-files-mt -wpad-basic -lighttpd-mod-openssl gl-ble-ubus gl-ble_cfg_router_telink gl-ipv6 gl-tor kmod-i2c-algo-bit kmod-i2c-core kmod-i2c-gpio kmod-i2c-gpio-custom i2c-tools libiwinfo-lua minidlna wireless-tools kmod-sdhci kmod-sdhci-mt7620 kmod-nft-core kmod-nft-nat kmod-nft-offload gl-upload gl-rtty gl-sdk4-mtk-wifi gl-sdk4-mtk-apcli -i2c-tools luci-base"
 		},
 		"mt300n-v2": {
 			"state": "develop",
@@ -104,7 +104,7 @@
 			"profile": "gl-mt300n-v2",
 			"version": "3.212",
 			"imagebuilder": "3.8/openwrt-imagebuilder-ramips-mt76x8_3.8",
-			"packages": "$glinet -gl-qos gl-qos-internal gl-base-files-mt -kmod-mt76 -kmod-mt76-core -kmod-mt7603 kmod-mt7628 $basic $vpn $storage $usb -wpa-cli -kmod-rt2800-usb -lighttpd-mod-openssl gl-sdk4-mtk-apcli mt76x8-uci2dat"
+			"packages": "$glinet -gl-qos gl-qos-internal gl-base-files-mt -kmod-mt76 -kmod-mt76-core -kmod-mt7603 kmod-mt7628 $basic $vpn $storage $usb -wpa-cli -kmod-rt2800-usb -lighttpd-mod-openssl gl-sdk4-mtk-apcli mt76x8-uci2dat -luci -luci-mod-rpc"
 		},
 		"n300": {
 			"state": "develop",
@@ -112,7 +112,7 @@
 			"profile": "microuter-n300",
 			"version": "3.212",
 			"imagebuilder": "3.8/openwrt-imagebuilder-ramips-mt76x8_3.8",
-			"packages": "$glinet -gl-qos gl-qos-internal gl-base-files-mt -kmod-mt76 -kmod-mt76-core -kmod-mt7603 kmod-mt7628 $basic $vpn $storage $usb -wpa-cli -kmod-rt2800-usb -lighttpd-mod-openssl gl-sdk4-mtk-apcli mt76x8-uci2dat"
+			"packages": "$glinet -gl-qos gl-qos-internal gl-base-files-mt -kmod-mt76 -kmod-mt76-core -kmod-mt7603 kmod-mt7628 $basic $vpn $storage $usb -wpa-cli -kmod-rt2800-usb -lighttpd-mod-openssl gl-sdk4-mtk-apcli mt76x8-uci2dat -luci -luci-mod-rpc"
 		},
 		"x300b": {
 			"state": "develop",
@@ -120,7 +120,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar gl-base-files-x300b gl-rs485 kmod-gl-hw-wdt $basic $vpn  $usb $glinet -gl-tor   gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl smstools3 ssmtp"
+			"packages": "gl-base-files-ar gl-base-files-x300b gl-rs485 kmod-gl-hw-wdt $basic $vpn  $usb $glinet -gl-tor   gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl smstools3 ssmtp -luci -luci-mod-rpc"
 		},
 		"x300b-nand": {
 			"state": "develop",
@@ -128,7 +128,7 @@
 			"version": "3.211",
 			"disabled": 1,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar gl-base-files-x300b gl-rs485 kmod-gl-hw-wdt $basic $vpn  $usb $glinet -gl-tor  gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl smstools3 ssmtp"
+			"packages": "gl-base-files-ar gl-base-files-x300b gl-rs485 kmod-gl-hw-wdt $basic $vpn  $usb $glinet -gl-tor  gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl smstools3 ssmtp -luci -luci-mod-rpc"
 		},
 		"x300b_2b": {
 			"state": "develop",
@@ -137,7 +137,7 @@
 			"type": "2B",
 			"disabled": 1,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar gl-base-files-x300b gl-base-files-wbf gl-rs485 kmod-gl-hw-wdt $basic $vpn  $usb $glinet -gl-tor gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl openvswitch kmod-openvswitch-intree gl-xwf -gl-ui gl-2b-ui gl-2b-env smstools3 ssmtp"
+			"packages": "gl-base-files-ar gl-base-files-x300b gl-base-files-wbf gl-rs485 kmod-gl-hw-wdt $basic $vpn  $usb $glinet -gl-tor gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl openvswitch kmod-openvswitch-intree gl-xwf -gl-ui gl-2b-ui gl-2b-env smstools3 ssmtp -luci -luci-mod-rpc"
 		},
 		"xe300": {
 			"state": "develop",
@@ -145,7 +145,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet gl-xe300-mcu -gl-tor  gl-xe300-mcu gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl kmod-usb-serial-ch341 smstools3 ssmtp luci luci-mod-rpc luci-base"
+			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet gl-xe300-mcu -gl-tor  gl-xe300-mcu gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl kmod-usb-serial-ch341 smstools3 ssmtp luci-base"
 		},
 		"xe300-iot": {
 			"state": "develop",
@@ -153,7 +153,7 @@
 			"disabled": 1,
 			"version": "3.211",
 			"imagebuilder": "3.8/openwrt-imagebuilder-ath79-nand_3.8",
-			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet gl-xe300-mcu -gl-tor gl-xe300-mcu gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl kmod-usb-serial-ch341 gl-bletool smstools3 ssmtp luci luci-mod-rpc luci-base"
+			"packages": "gl-base-files-ar $basic $vpn $storage $usb $glinet gl-xe300-mcu -gl-tor gl-xe300-mcu gl-upload gl-ipv6 gl-rtty -wpad -wpad-basic wpad-openssl -lighttpd-mod-openssl kmod-usb-serial-ch341 gl-bletool smstools3 ssmtp luci-base"
 		},
 		"mv1000-emmc": {
 			"state": "release",
@@ -161,7 +161,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.8/openwrt-imagebuilder-mvebu-cortexa53_3.8",
-			"packages": "kmod-8192eu kmod-8812au kmod-8821cu kmod-8811au kmod-usb-gadget-eth gl-base-files-mv1000 $basic -kmod-usb-serial-cp210x -lighttpd-mod-openssl $vpn $storage $usb -kmod-rt2800-usb $glinet gl-s2s -kmod-GobiNet -kmod-GobiSerial -gl-qos gl-qos-internal gl-tertf gl-tor haveged usbutils wpa-cli AdGuardHome gl-agh-stats -gl-upload luci luci-mod-rpc luci-base"
+			"packages": "kmod-8192eu kmod-8812au kmod-8821cu kmod-8811au kmod-usb-gadget-eth gl-base-files-mv1000 $basic -kmod-usb-serial-cp210x -lighttpd-mod-openssl $vpn $storage $usb -kmod-rt2800-usb $glinet gl-s2s -kmod-GobiNet -kmod-GobiSerial -gl-qos gl-qos-internal gl-tertf gl-tor haveged usbutils wpa-cli AdGuardHome gl-agh-stats -gl-upload luci-base"
 		},
 		"ap1300": {
 			"state": "release",
@@ -169,7 +169,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.5/openwrt-imagebuilder-ipq-ipq40xx-QSDK_Premium_3.5",
-			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty gl-ble-api gl-ble-daemon gl-agh-stats  kmod-gl-hw-wdt kmod-rtc-sd2068 kmod-i2c-gpio-custom gl-agh-stats smstools3 ssmtp luci luci-mod-rpc luci-base"
+			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty gl-ble-api gl-ble-daemon gl-agh-stats  kmod-gl-hw-wdt kmod-rtc-sd2068 kmod-i2c-gpio-custom gl-agh-stats smstools3 ssmtp luci-base"
 		},
 		"b1300": {
 			"state": "release",
@@ -177,7 +177,7 @@
 			"version": "3.212",
 			"disabled": 0,
 			"imagebuilder": "3.5/openwrt-imagebuilder-ipq-ipq40xx-QSDK_Premium_3.5",
-			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty luci luci-mod-rpc luci-base"
+			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty luci-base"
 		},
 		"b1300_2b": {
 			"state": "develop",
@@ -186,7 +186,7 @@
 			"disabled": 1,
 			"type": "2B",
 			"imagebuilder": "3.8/openwrt-imagebuilder-ipq-ipq40xx-QSDK_Premium_3.8",
-			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq gl-base-files-wbf $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-rtty openvswitch kmod-openvswitch-intree gl-xwf -gl-ui gl-2b-ui gl-2b-env luci luci-mod-rpc luci-base"
+			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq gl-base-files-wbf $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-rtty openvswitch kmod-openvswitch-intree gl-xwf -gl-ui gl-2b-ui gl-2b-env luci-base"
 		},
 		"b2200": {
 			"state": "develop",
@@ -195,7 +195,7 @@
 			"version": "3.212",
             "files":"imagebuilder/3.5/openwrt-imagebuilder-ipq-ipq40xx-QSDK_Premium_3.5/files",
 			"imagebuilder": "3.5/openwrt-imagebuilder-ipq-ipq40xx-QSDK_Premium_3.5",
-			"packages": "-wpad-openssl gl-upload gl-b2200-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty gl-tor kmod-i2c-gpio-custom gl-agh-stats gl-ble_config_wifi gl-bletool gl-ble-ubus luci luci-mod-rpc luci-base"
+			"packages": "-wpad-openssl gl-upload gl-b2200-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty gl-tor kmod-i2c-gpio-custom gl-agh-stats gl-ble_config_wifi gl-bletool gl-ble-ubus luci-base"
 		},
 		"s1300": {
 			"state": "release",
@@ -203,25 +203,25 @@
 			"profile": "QSDK_Premium",
 			"version": "3.212",
 			"imagebuilder": "3.5/openwrt-imagebuilder-ipq-ipq40xx-QSDK_Premium_3.5",
-			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty gl-ble-api gl-ble-daemon gl-agh-stats luci luci-mod-rpc luci-base"
+			"packages": "-wpad-openssl gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor gl-rtty gl-ble-api gl-ble-daemon gl-agh-stats luci-base"
 		},
 		"sf1200": {
 			"profile": "SF19A28-GL-SF1200",
 			"version": "3.212",
 			"imagebuilder": "3.8/openwrt-imagebuilder-siflower-sf19a28_3.8",
-			"packages": "-gl-init-portal -gl-siderouter -kmod-leds-gpio -ubi-utils -gl-portal -gl-modem gl-base-files-sf  gl-ddns  gl-fw  gl-mqtt -gl-tertf gl-tertf-sf1200 gl-traffic gl-sdk4-carrier-monitor $basic $vpn $glinet $siflower_driver"
+			"packages": "-gl-init-portal -gl-siderouter -kmod-leds-gpio -ubi-utils -gl-portal -gl-modem gl-base-files-sf  gl-ddns  gl-fw  gl-mqtt -gl-tertf gl-tertf-sf1200 gl-traffic gl-sdk4-carrier-monitor $basic $vpn $glinet $siflower_driver -luci -luci-mod-rpc"
 			},
 		"sft1200": {
 			"profile": "SF19A28-GL-SFT1200",
 			"version": "3.212",
 			"imagebuilder": "3.8/openwrt-imagebuilder-siflower-sf19a28-nand_3.8",
-			"packages": "-gl-init-portal -gl-siderouter -kmod-leds-gpio blockdev gl-base-files-sf gl-tor $basic $vpn $storage $usb $glinet $siflower_driver"
+			"packages": "-gl-init-portal -gl-siderouter -kmod-leds-gpio blockdev gl-base-files-sf gl-tor $basic $vpn $storage $usb $glinet $siflower_driver -luci -luci-mod-rpc"
 			},
 		"ax1800": {
 			"profile": "QSDK_Premium",
 			"version": "3.214",
 			"imagebuilder": "3.6/openwrt-imagebuilder-ipq-ipq60xx-QSDK_Premium_3.6",
-			"packages": "-wpad-openssl gl-ble-ubus gl-ble_cfg_ax1800 gl-agh-stats gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor rtty-openssl -lighttpd-mod-openssl gl-ipv6 bridge luci luci-mod-rpc kmod-i2c-gpio-custom gl-rtty kmod-mtdoops gl-sdk4-logread gl-init-portal"
+			"packages": "-wpad-openssl gl-ble-ubus gl-ble_cfg_ax1800 gl-agh-stats gl-upload gl-wifison gl-base-files-ipq $glinet -gl-qos gl-qos-internal $vpn $basic $storage $usb -wpad -wpa-cli -kmod-rt2800-usb -kmod-GobiNet -kmod-GobiSerial -kmod-usb-storage-uas gl-tor rtty-openssl -lighttpd-mod-openssl gl-ipv6 bridge kmod-i2c-gpio-custom gl-rtty kmod-mtdoops gl-sdk4-logread gl-init-portal"
 		}
 	}
 }


### PR DESCRIPTION
Replace 'openwrt-imagebuilder-ramips-mt7621-newdriver_3.8' with 'openwrt-imagebuilder-ramips-mt7621_3.8'.
Fix cloning error when compiling with imagebuilder.